### PR TITLE
Fix: Correct footer GitHub icon link to repository

### DIFF
--- a/index.html
+++ b/index.html
@@ -248,7 +248,7 @@
               Manage your income, expenses, and financial goals effortlessly.
             </p>
             <div class="social-links">
-              <a href="#" class="social-link"><i class="fab fa-github"></i></a>
+              <a href="https://github.com/neeraj542/Personal-Finance-Tracker" target="_blank" rel="noopener noreferrer" class="social-link"><i class="fab fa-github"></i></a>
               <a href="#" class="social-link"><i class="fab fa-linkedin"></i></a>
               <a href="#" class="social-link"><i class="fab fa-twitter"></i></a>
               <a href="#" class="social-link"><i class="fab fa-facebook"></i></a>


### PR DESCRIPTION
Closes #73

This Pull Request fixes the incorrect link for the GitHub icon in the website footer.

The `href` attribute was pointing to the top of the page, and it has been updated to point to the correct project repository URL. I also added the `target="_blank"` attribute so that the link opens in a new tab, which improves the user experience for external links.

This is ready for review. Thank you!